### PR TITLE
Update numpy to version 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pandas>=2.0.3
 beautifulsoup4>=4.12.2
 requests>=2.31.0
 selenium==4.18.1
-numpy==1.25.1
+numpy==2.0.1


### PR DESCRIPTION
Updating numpy to version 2.0.1 resolves installation issues with Python 3.12. The newest numpy version does not depend on distutils anymore, which was required before. Python 3.12 is shipped without distutils and that lead to problems during installation with the older numpy version.