### PR TITLE
32 support macrotrends quarterly frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,9 +324,9 @@ from stockdex import Ticker
 ticker = Ticker(ticker="AAPL")
 
 # Financial data
-income_statement = ticker.macrotrends_income_statement
-balance_sheet = ticker.macrotrends_balance_sheet
-cash_flow = ticker.macrotrends_cash_flow
+income_statement = ticker.macrotrends_income_statement(frequency="quarterly")
+balance_sheet = ticker.macrotrends_balance_sheet(frequency="quarterly")
+cash_flow = ticker.macrotrends_cash_flow(frequency="annual")
 key_financial_ratios = ticker.macrotrends_key_financial_ratios
 
 # Margins

--- a/stockdex/macrotrends_interface.py
+++ b/stockdex/macrotrends_interface.py
@@ -93,18 +93,13 @@ class MacrotrendsInterface(TickerBase):
         check_security_type(self.security_type, valid_types=["stock"])
         frequency_suffix = "?freq=A" if frequency == "annual" else "?freq=Q"
 
-        if frequency == "annual":
-            url = f"{MACROTRENDS_BASE_URL}/{self.ticker}/TBD/income-statement{frequency_suffix}"
-            response = self.get_response(url)
+        url = (
+            f"{MACROTRENDS_BASE_URL}/{self.ticker}/{self.get_company_slug(self.ticker)}/income-statement{frequency_suffix}"  # Noqa E501
+            if frequency == "quarterly"
+            else f"{MACROTRENDS_BASE_URL}/{self.ticker}/TBD/income-statement{frequency_suffix}"
+        )
 
-        elif frequency == "quarterly":
-            url = f"{MACROTRENDS_BASE_URL}/{self.ticker}/TBD/income-statement{frequency_suffix}"
-            response = self.get_response(url)
-
-            # get the company slug from the response
-            company_slug = response.url.split("/")[-2]
-            url = f"{MACROTRENDS_BASE_URL}/{self.ticker}/{company_slug}/income-statement{frequency_suffix}"  # Noqa E501
-            response = self.get_response(url)
+        response = self.get_response(url)
 
         # Parse the HTML content of the website
         soup = BeautifulSoup(response.content, "html.parser")

--- a/stockdex/macrotrends_interface.py
+++ b/stockdex/macrotrends_interface.py
@@ -356,6 +356,12 @@ class MacrotrendsInterface(TickerBase):
 
         Args:
         ----------
+        fields_to_include : list
+            The fields to include in the plot.
+        frequency : Literal["annual", "quarterly"]
+            The frequency of the data to plot.
+        group_by : Literal["field", "timeframe"]
+            The level at which to group the data.
         show_plot : bool
             If the plot should be shown or not.
             If dash is used, this should be set to False
@@ -395,6 +401,12 @@ class MacrotrendsInterface(TickerBase):
 
         Args:
         ----------
+        fields_to_include : list
+            The fields to include in the plot.
+        frequency : Literal["annual", "quarterly"]
+            The frequency of the data to plot.
+        group_by : Literal["field", "timeframe"]
+            The level at which to group the data.
         show_plot : bool
             If the plot should be shown or not.
             If dash is used, this should be set to False

--- a/stockdex/ticker.py
+++ b/stockdex/ticker.py
@@ -1,11 +1,11 @@
 from stockdex.config import VALID_SECURITY_TYPES
 from stockdex.digrin_interface import DigrinInterface
+from stockdex.finviz_interface import FinvizInterface
 from stockdex.justetf_interface import JustETF
 from stockdex.macrotrends_interface import MacrotrendsInterface
 from stockdex.sankey_charts import SankeyCharts
 from stockdex.yahoo_api_interface import YahooAPI
 from stockdex.yahoo_web_interface import YahooWeb
-from stockdex.finviz_interface import FinvizInterface
 
 
 class Ticker(

--- a/stockdex/ticker_base.py
+++ b/stockdex/ticker_base.py
@@ -8,7 +8,7 @@ from typing import Union
 from bs4 import BeautifulSoup
 from curl_cffi import requests
 
-from stockdex.config import RESPONSE_TIMEOUT
+from stockdex.config import MACROTRENDS_BASE_URL, RESPONSE_TIMEOUT
 from stockdex.lib import get_user_agent
 
 
@@ -105,3 +105,13 @@ class TickerBase:
                     element = element.find_next(tag)
                 return element
         return None
+
+    def get_company_slug(self, ticker: str) -> str:
+        """
+        Retrieve the company slug for the given ticker using macrotrends.
+        """
+        url = f"{MACROTRENDS_BASE_URL}/{ticker}/TBD/income-statement"
+        response = self.get_response(url)
+        company_slug = response.url.split("/")[-2]
+
+        return company_slug

--- a/stockdex/yahoo_web_interface.py
+++ b/stockdex/yahoo_web_interface.py
@@ -38,12 +38,12 @@ class YahooWeb(TickerBase):
         pd.DataFrame: A pandas DataFrame including the financials table
         """
         response = self.get_response(url)
-        soup = BeautifulSoup(response.content, "html.parser").find(
-            "div", {"class": "table yf-9ft13"}
-        )
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        table = self.find_parent_by_text(soup, "div", "Breakdown")
 
         # Extract column headers
-        header_row = soup.find("div", class_="tableHeader")
+        header_row = table.find("div", class_="tableHeader")
         columns = [
             col.get_text(strip=True)
             for col in header_row.find_all("div", class_="column")

--- a/stockdex/yahoo_web_interface.py
+++ b/stockdex/yahoo_web_interface.py
@@ -354,12 +354,13 @@ class YahooWeb(TickerBase):
 
         # Parse the HTML content of the website
         soup = BeautifulSoup(response.content, "html.parser")
-        raw_data = soup.find_all("table")
+        table = self.find_parent_by_text(
+            soup, "div", "Top Institutional Holders"
+        ).find_all("tr")
 
         data_df = pd.DataFrame()
         data = []
 
-        table = raw_data[2].find_all("tr")
         for tr in table:
             data.append([td.text for td in tr.find_all("td")])
 

--- a/tests/test_macrotrends_interface.py
+++ b/tests/test_macrotrends_interface.py
@@ -36,6 +36,9 @@ def test_macrotrends_income_statement(ticker, frequency):
         assert macrotrends_income_statement.shape[1] > 6
 
 
+@pytest.mark.skipif(
+    skip_test, reason="Skipping in GH action as it reaches the limit of requests"
+)
 @pytest.mark.parametrize(
     "ticker, frequency",
     [
@@ -58,6 +61,9 @@ def test_macrotrends_balance_sheet(ticker, frequency):
         assert macrotrends_balance_sheet.shape[1] > 6
 
 
+@pytest.mark.skipif(
+    skip_test, reason="Skipping in GH action as it reaches the limit of requests"
+)
 @pytest.mark.parametrize(
     "ticker, frequency",
     [

--- a/tests/test_macrotrends_interface.py
+++ b/tests/test_macrotrends_interface.py
@@ -30,40 +30,54 @@ def test_macrotrends_income_statement(ticker, frequency):
     assert "Revenue" in macrotrends_income_statement.index
     assert "Gross Profit" in macrotrends_income_statement.index
     assert "Operating Income" in macrotrends_income_statement.index
+    if frequency == "quarterly":
+        assert macrotrends_income_statement.shape[1] > 28
+    else:
+        assert macrotrends_income_statement.shape[1] > 6
 
 
 @pytest.mark.parametrize(
-    "ticker",
+    "ticker, frequency",
     [
-        ("BAC"),
+        ("BAC", "quarterly"),
+        ("BAC", "annual"),
     ],
 )
-def test_macrotrends_balance_sheet(ticker):
+def test_macrotrends_balance_sheet(ticker, frequency):
     ticker = Ticker(ticker=ticker)
-    macrotrends_balance_sheet = ticker.macrotrends_balance_sheet
+    macrotrends_balance_sheet = ticker.macrotrends_balance_sheet(frequency=frequency)
 
     # Check if the response is as expected
     assert isinstance(macrotrends_balance_sheet, pd.DataFrame)
     assert macrotrends_balance_sheet.shape[0] > 0
     assert macrotrends_balance_sheet.shape[1] > 0
     assert "Total Assets" in macrotrends_balance_sheet.index
+    if frequency == "quarterly":
+        assert macrotrends_balance_sheet.shape[1] > 28
+    else:
+        assert macrotrends_balance_sheet.shape[1] > 6
 
 
 @pytest.mark.parametrize(
-    "ticker",
+    "ticker, frequency",
     [
-        ("PANW"),
+        ("PANW", "quarterly"),
+        ("PANW", "annual"),
     ],
 )
-def test_macrotrends_cash_flow(ticker):
+def test_macrotrends_cash_flow(ticker, frequency):
     ticker = Ticker(ticker=ticker)
-    macrotrends_cash_flow = ticker.macrotrends_cash_flow
+    macrotrends_cash_flow = ticker.macrotrends_cash_flow(frequency=frequency)
 
     # Check if the response is as expected
     assert isinstance(macrotrends_cash_flow, pd.DataFrame)
     assert macrotrends_cash_flow.shape[0] > 0
     assert macrotrends_cash_flow.shape[1] > 0
     assert macrotrends_cash_flow.iloc[0][1] is not None
+    if frequency == "quarterly":
+        assert macrotrends_cash_flow.shape[1] > 28
+    else:
+        assert macrotrends_cash_flow.shape[1] > 6
 
 
 @pytest.mark.skipif(
@@ -183,39 +197,42 @@ def test_macrotrends_net_margin(ticker):
 
 @pytest.mark.skipif(skip_test, reason="Skipping in GH action as it is visual")
 @pytest.mark.parametrize(
-    "ticker, group_by",
+    "ticker, group_by, frequency",
     [
-        ("AAPL", "field"),
-        ("GOOGL", "timeframe"),
+        ("AAPL", "field", "quarterly"),
+        ("GOOGL", "timeframe", "annual"),
+        ("GOOGL", "timeframe", "quarterly"),
     ],
 )
-def test_plot_macrotrends_income_statement(ticker, group_by):
+def test_plot_macrotrends_income_statement(ticker, group_by, frequency):
     ticker = Ticker(ticker=ticker)
-    ticker.plot_macrotrends_income_statement(group_by=group_by)
+    ticker.plot_macrotrends_income_statement(group_by=group_by, frequency=frequency)
     assert True
 
 
 @pytest.mark.skipif(skip_test, reason="Skipping in GH action as it is visual")
 @pytest.mark.parametrize(
-    "ticker, group_by",
+    "ticker, group_by, frequency",
     [
-        ("AAPL", "field"),
-        ("GOOGL", "timeframe"),
+        ("AAPL", "field", "quarterly"),
+        ("GOOGL", "timeframe", "annual"),
+        ("GOOGL", "timeframe", "quarterly"),
     ],
 )
-def test_plot_macrotrends_balance_sheet(ticker, group_by):
+def test_plot_macrotrends_balance_sheet(ticker, group_by, frequency):
     ticker = Ticker(ticker=ticker)
-    ticker.plot_macrotrends_balance_sheet(group_by=group_by)
+    ticker.plot_macrotrends_balance_sheet(group_by=group_by, frequency=frequency)
 
 
 @pytest.mark.skipif(skip_test, reason="Skipping in GH action as it is visual")
 @pytest.mark.parametrize(
-    "ticker, group_by",
+    "ticker, group_by, frequency",
     [
-        ("AAPL", "field"),
-        ("GOOGL", "timeframe"),
+        ("AAPL", "field", "quarterly"),
+        ("GOOGL", "timeframe", "annual"),
+        ("GOOGL", "timeframe", "quarterly"),
     ],
 )
-def test_plot_macrotrends_cash_flow(ticker, group_by):
+def test_plot_macrotrends_cash_flow(ticker, group_by, frequency):
     ticker = Ticker(ticker=ticker)
-    ticker.plot_macrotrends_cash_flow(group_by=group_by)
+    ticker.plot_macrotrends_cash_flow(group_by=group_by, frequency=frequency)

--- a/tests/test_macrotrends_interface.py
+++ b/tests/test_macrotrends_interface.py
@@ -9,20 +9,27 @@ skip_test = bool(os.getenv("SKIP_TEST", False))
 
 
 @pytest.mark.parametrize(
-    "ticker",
+    "ticker, frequency",
     [
-        ("PANW"),
+        ("PANW", "quarterly"),
+        ("PANW", "annual"),
+        ("BAC", "annual"),
+        ("BAC", "quarterly"),
     ],
 )
-def test_macrotrends_income_statement(ticker):
+def test_macrotrends_income_statement(ticker, frequency):
     ticker = Ticker(ticker=ticker)
-    macrotrends_income_statement = ticker.macrotrends_income_statement
+    macrotrends_income_statement = ticker.macrotrends_income_statement(
+        frequency=frequency
+    )
 
     # Check if the response is as expected
     assert isinstance(macrotrends_income_statement, pd.DataFrame)
     assert macrotrends_income_statement.shape[0] > 0
     assert macrotrends_income_statement.shape[1] > 0
     assert "Revenue" in macrotrends_income_statement.index
+    assert "Gross Profit" in macrotrends_income_statement.index
+    assert "Operating Income" in macrotrends_income_statement.index
 
 
 @pytest.mark.parametrize(

--- a/tests/test_macrotrends_interface.py
+++ b/tests/test_macrotrends_interface.py
@@ -242,3 +242,23 @@ def test_plot_macrotrends_balance_sheet(ticker, group_by, frequency):
 def test_plot_macrotrends_cash_flow(ticker, group_by, frequency):
     ticker = Ticker(ticker=ticker)
     ticker.plot_macrotrends_cash_flow(group_by=group_by, frequency=frequency)
+
+
+@pytest.mark.skipif(
+    skip_test, reason="Skipping in GH action as it reaches the limit of requests"
+)
+@pytest.mark.parametrize(
+    "ticker, frequency",
+    [
+        ("PANW", "annual"),
+        ("GOOGL", "quarterly"),
+    ],
+)
+def test_macrotrends_revenue(ticker, frequency):
+    ticker = Ticker(ticker)
+    macrotrends_revenue = ticker.macrotrends_revenue(frequency=frequency)
+
+    # Check if the response is as expected
+    assert isinstance(macrotrends_revenue, pd.DataFrame)
+    assert macrotrends_revenue.shape[0] > 0
+    assert macrotrends_revenue.shape[1] > 0

--- a/tests/test_yahoo_web_interface.py
+++ b/tests/test_yahoo_web_interface.py
@@ -190,23 +190,6 @@ def test_yahoo_web_corporate_governance_wrong_security_type():
 
 
 @pytest.mark.parametrize(
-    "ticker, frequency",
-    [
-        ("PANW", "annual"),
-        ("GOOGL", "quarterly"),
-    ],
-)
-def test_macrotrends_revenue(ticker, frequency):
-    ticker = Ticker(ticker)
-    macrotrends_revenue = ticker.macrotrends_revenue(frequency=frequency)
-
-    # Check if the response is as expected
-    assert isinstance(macrotrends_revenue, pd.DataFrame)
-    assert macrotrends_revenue.shape[0] > 0
-    assert macrotrends_revenue.shape[1] > 0
-
-
-@pytest.mark.parametrize(
     "ticker",
     [
         ("AAPL"),


### PR DESCRIPTION
- Add quarterly support to macrotrends functions
- Add method to base ticket class to fetch full company names (AKA `company_slug`s) from macrotrends
- Cache macrotrends function results for efficiency 