### PR TITLE
remove unecessary module "requests"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ beautifulsoup4==4.12.3
 numpy
 pandas>=2.2.3
 plotly>=5.24.1
-Requests==2.32.3
 selenium==4.25.0
 plotly>=5.24.1
 dash>=2.18.0

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -10,7 +10,6 @@ myst-parser==2.0.0
 pandas==2.0.3
 beautifulsoup4==4.12.2
 pytest >=8.0.0
-requests==2.31.0
 selenium==4.18.1
 numpy==1.25.1
 plotly==5.24.1


### PR DESCRIPTION
As it stands, the `requirements.txt` file requires `requests==2.23.3`. This version has the vulnerability [[CVE-2024-47081](https://www.cvedetails.com/cve/CVE-2024-47081/)](https://www.cvedetails.com/cve/CVE-2024-47081/). A full analysis of the code using Copilot concluded that the module `requests` is never actually used, only the function "requests" from the `curl_cffi` module is used.

This pull request removes the package `requests` from the repository. Original pull request: https://github.com/MauGx3/stockdex/pull/1